### PR TITLE
Replace deprected Float.to_string function

### DIFF
--- a/lib/ex_marshal/encoder.ex
+++ b/lib/ex_marshal/encoder.ex
@@ -94,7 +94,7 @@ defmodule ExMarshal.Encoder do
   end
 
   defp encode_float(value, state) do
-    value_str = Float.to_string(value, [decimals: 10, compact: true])
+    value_str = :erlang.float_to_binary(value, [:compact, decimals: 10])
 
     {encoded_value, state} = encode_raw_string(value_str, state)
 


### PR DESCRIPTION
Function was deprecated in favor of `:erlang.float_to_string/2`

https://github.com/elixir-lang/elixir/pull/5039