### PR TITLE
Relax decimal version dependency to work with ecto.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExMarshal.Mixfile do
 
   defp deps do
     [
-      {:decimal, "~> 1.1.0"},
+      {:decimal, "~> 1.1"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"decimal": {:hex, :decimal, "1.1.0", "3333732f17a90ff3057d7ab8c65f0930ca2d67e15cca812a91ead5633ed472fe", [:mix], []},
+%{"decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
Heres what I get when trying to add this into a new project with the latest ecto:

```elixir
$ mix deps.get
Running dependency resolution

Failed to use "decimal" (version 1.3.1) because
  ecto (version 2.1.0-rc.3) requires ~> 1.2
  ex_marshal (versions 0.0.1 to 0.0.5) requires ~> 1.1.0
  postgrex (version 0.12.1) requires ~> 1.0
  mix.lock specifies 1.3.1

** (Mix) Hex dependency resolution failed, relax the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}
```

Relaxing it passes all tests and it doesn't seem like your usage of it is too heavy, so this shouldn't hurt anything.