### PR TITLE
Decode small integers from 118 to 122

### DIFF
--- a/lib/ex_marshal/decoder.ex
+++ b/lib/ex_marshal/decoder.ex
@@ -49,7 +49,7 @@ defmodule ExMarshal.Decoder do
 
     case fixnum_type do
       0 -> {0, fixnum_data, state}
-      v when v >= 6 and v <= 122 ->
+      v when v >= 6 and v <= 127 ->
         <<fixnum::signed-little-integer-size(8)>> = <<v>>
 
         {fixnum - 5, fixnum_data, state}

--- a/test/ex_marshal/decoder_test.exs
+++ b/test/ex_marshal/decoder_test.exs
@@ -69,6 +69,12 @@ defmodule ExMarshalDecoderTest do
     assert 100 == decoded_int
   end
 
+  test "decode small integer 2" do
+    decoded_int = ExMarshal.decode(<<4, 8, 105, 123>>)
+
+    assert 118 == decoded_int
+  end
+
   test "decode small negative integer" do
     decoded_int = ExMarshal.decode(<<4, 8, 105, 131>>)
 


### PR DESCRIPTION
This PR fixes exception about decoding 118-122 fixnum and decoding strings which has 118-122 length.

Please refer to https://docs.ruby-lang.org/en/2.2.0/marshal_rdoc.html#label-Fixnum+and+long

# How to test
```elixir
iex> <<4, 8, 105, 123>> |> ExMarshal.decode
118
iex> <<4, 8, 105, 127>> |> ExMarshal.decode
122
iex> "this string has 120 bytes this string has 120 bytesthis string has 120 bytesthis string has 120 bytesthis string has 120" |> ExMarshal.encode |> ExMarshal.decode
"this string has 120 bytes this string has 120 bytesthis string has 120 bytesthis string has 120 bytesthis string has 120"
iex>
```