### PR TITLE
add unsupported data_types & connect their handling to nullify_object…

### DIFF
--- a/lib/ex_marshal/decoder.ex
+++ b/lib/ex_marshal/decoder.ex
@@ -39,7 +39,7 @@ defmodule ExMarshal.Decoder do
 
         decode_hash(value, state)
       "@" -> decode_reference(value, state)
-      "o" when nullify_objects -> {nil, value, state}
+      symbol when nullify_objects -> {nil, value, state}
       symbol -> raise ExMarshal.DecodeError, reason: {:not_supported, symbol}
     end
   end


### PR DESCRIPTION
Allow nullify_objects option nullify other unsupported data types.
https://github.com/ruby/ruby/blob/b01c28eeb3942bce1ddf9b9243ecf727d5421c6d/doc/marshal.rdoc