### PR TITLE
Consider string encoding symbol

### DIFF
--- a/test/ex_marshal/decoder_test.exs
+++ b/test/ex_marshal/decoder_test.exs
@@ -375,12 +375,17 @@ defmodule ExMarshalDecoderTest do
     end
   end
 
-
   test "raises exception for non-supported symbol" do
     ruby_encoded = File.read!("./test/fixtures/regexp.bin")
 
     assert_raise ExMarshal.DecodeError, fn ->
       ExMarshal.decode(ruby_encoded)
     end
+  end
+
+  test "decode repetitive symbols" do
+    value = <<4, 8, 123, 6, 73, 34, 6, 120, 6, 58, 6, 69, 84, 91, 7, 58, 12, 115, 117, 99, 99, 101, 115, 115, 59, 6>>
+
+    assert %{"x" => [:success, :success]} == ExMarshal.decode(value)
   end
 end

--- a/test/ex_marshal_test.exs
+++ b/test/ex_marshal_test.exs
@@ -43,4 +43,12 @@ defmodule ExMarshalTest do
 
     assert string == ExMarshal.encode(string) |> ExMarshal.decode
   end
+
+  test "repetitive symbols" do
+    original_value = %{first: %{key: [:success]}, second: %{success: "yes"}}
+    ruby_encoded = File.read!("./test/fixtures/repetitive_symbols.bin")
+    ex_marshal_encoded = ExMarshal.encode(original_value)
+
+    assert ExMarshal.decode(ruby_encoded) == ExMarshal.decode(ex_marshal_encoded)
+  end
 end

--- a/test/fixtures/repetitive_symbols.bin
+++ b/test/fixtures/repetitive_symbols.bin
@@ -1,0 +1,2 @@
+{:
+first{:key[:success:second{;I"yes:ET


### PR DESCRIPTION
While decoding string, the encoding symbol should go to symbols dict as any other symbol, because this symbol can be referenced as well.

Also this PR fixes encoding symbols: the problem was that while encoding symbols and counting them in dict, the index for symbols would be encoded according to ruby marshal format, which would mean that instead of `%{foo: 0, bar: 1}` the dict would look like `%{foo: 0, bar: 6}` (6 is encoded 1). 

closes https://github.com/gaynetdinov/ex_marshal/issues/19