### PR TITLE
Make it possible to use Decimal 2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExMarshal.Mixfile do
 
   defp deps do
     [
-      {:decimal, "~> 1.5"},
+      {:decimal, "~> 1.5 or ~> 2.0"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end


### PR DESCRIPTION
In my project I use Decimal 2.0 
Currently we need to use the override: true option in the deps.
I saw that this project only uses Decimal.new and Decimal.to_string which are equivalent in 1.5 and 2.0

