### PR TITLE
Support decoding user-marshalled objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ iex(2)> ExMarshal.encode([1, 2, 3])
 iex(3)>
 ```
 
+It is also possible to decode user objects such as Ruby dates using custom parsers which can be specified via the `user_object_parsers` option:
+
+```elixir
+iex(1)> value = <<4, 8, 85, 58, 9, 68, 97, 116, 101, 91, 11, 105, 0, 105, 3, 72, 136, 37, 105, 0, 105, 0, 105, 0, 102, 12, 50, 50, 57, 57, 49, 54, 49>>
+<<4, 8, 85, 58, 9, 68, 97, 116, 101, 91, 11, 105, 0, 105, 3, 72, 136, 37, 105,
+  0, 105, 0, 105, 0, 102, 12, 50, 50, 57, 57, 49, 54, 49>>
+iex(2)> ExMarshal.decode(value, user_object_parsers: %{Date: fn [_, julian_day, _, _, _, _] -> Date.from_gregorian_days(julian_day - 1721425) end})
+~D[2021-05-20]
+```
+
 ## Nullify Ruby Objects
 
 The default behaviour of ExMarshal is to raise an error when trying to decode an serilized ruby object. This config option can be used to nullify the ruby object without raising an error:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `ExMarshal` encodes and decodes Elixir terms according to [Ruby Marshal](http://docs.ruby-lang.org/en/2.2.0/marshal_rdoc.html) format.
 
-Currently supported Ruby types are `nil`, `false`, `true`, `Fixnum`, `Bignum`, `BigDecimal`, `Float`, `Symbol`, `String`, `Array`, `Hash`.
+Currently supported Ruby types are `nil`, `false`, `true`, `Fixnum`, `Bignum`, `BigDecimal`, `Float`, `Symbol`, `String`, `Array`, `Hash` as well as user-defined types such as `Date`.
 
 ## Why?
 

--- a/lib/ex_marshal.ex
+++ b/lib/ex_marshal.ex
@@ -3,7 +3,7 @@ defmodule ExMarshal do
     ExMarshal.Encoder.encode(value)
   end
 
-  def decode(value) do
-    ExMarshal.Decoder.decode(value)
+  def decode(value, opts \\ []) do
+    ExMarshal.Decoder.decode(value, opts)
   end
 end

--- a/lib/ex_marshal/decoder.ex
+++ b/lib/ex_marshal/decoder.ex
@@ -299,7 +299,7 @@ defmodule ExMarshal.Decoder do
       references_state = Map.put(state.references, :count, references_count)
       references_state = Map.put(references_state, references_count, value)
 
-      %{links: state.links, references: references_state}
+      %{state | references: references_state}
     end
   end
 

--- a/lib/ex_marshal/decoder.ex
+++ b/lib/ex_marshal/decoder.ex
@@ -56,6 +56,8 @@ defmodule ExMarshal.Decoder do
         decode_hash(value, state)
       "@" ->
         decode_reference(value, state)
+      "U" ->
+        decode_user_object(value, state)
       symbol ->
         if nullify_objects?() do
           {nil, value, state}
@@ -283,6 +285,13 @@ defmodule ExMarshal.Decoder do
     {reference, _rest, state} = decode_fixnum(<<reference>>, state)
 
     {state.references[reference], rest, state}
+  end
+
+  defp decode_user_object(<<?:, rest::binary>>, state) do
+    {class_name, rest, state} = decode_symbol(rest, state)
+    {attributes, rest, state} = decode_element(rest, state)
+
+    {{class_name, attributes}, rest, state}
   end
 
   defp update_references(value, state) do

--- a/lib/ex_marshal/decoder.ex
+++ b/lib/ex_marshal/decoder.ex
@@ -1,7 +1,7 @@
 defmodule ExMarshal.Decoder do
   alias ExMarshal.Errors.DecodeError
 
-  def decode(<<_major::1-bytes, _minor::1-bytes, value::binary>>) do
+  def decode(<<_major::1-bytes, _minor::1-bytes, value::binary>>, opts \\ []) do
     initial_state = %{
       links: %{},
       references: %{locked: false, first_call: true}

--- a/test/ex_marshal/decoder_test.exs
+++ b/test/ex_marshal/decoder_test.exs
@@ -401,4 +401,11 @@ defmodule ExMarshalDecoderTest do
     assert ExMarshal.decode(list_500) == Enum.to_list(1..500)
     assert ExMarshal.decode(list_70000) == Enum.to_list(1..70000)
   end
+
+  test "decode user object" do
+    # Marshal.dump(Date.today).chars.map(&:ord)
+    value = <<4, 8, 85, 58, 9, 68, 97, 116, 101, 91, 11, 105, 0, 105, 3, 72, 136, 37, 105, 0, 105, 0, 105, 0, 102, 12, 50, 50, 57, 57, 49, 54, 49>>
+
+    assert {:Date, [0, 2459720, 0, 0, 0, 2299161.0]} == ExMarshal.decode(value)
+  end
 end

--- a/test/ex_marshal/decoder_test.exs
+++ b/test/ex_marshal/decoder_test.exs
@@ -408,4 +408,17 @@ defmodule ExMarshalDecoderTest do
 
     assert {:Date, [0, 2459720, 0, 0, 0, 2299161.0]} == ExMarshal.decode(value)
   end
+
+  test "decode user object with custom parser" do
+    # Marshal.dump(Date.today).chars.map(&:ord)
+    value = <<4, 8, 85, 58, 9, 68, 97, 116, 101, 91, 11, 105, 0, 105, 3, 72, 136, 37, 105, 0, 105, 0, 105, 0, 102, 12, 50, 50, 57, 57, 49, 54, 49>>
+
+    custom_parsers = %{
+      Date: fn [_, julian_day, _, _, _, _] ->
+        Date.from_gregorian_days(julian_day - 1721425)
+      end
+    }
+
+    assert ~D[2021-05-20] == ExMarshal.decode(value, user_object_parsers: custom_parsers)
+  end
 end


### PR DESCRIPTION
This PR implements two enhancements which permit decoding user-marshalled objects (indicated by the `U` type code):

1. Whenever encountering a user-defined object (e.g. a Ruby date) in a stream, the code now emits a 2-tuple giving the object's Ruby class name (a symbol, e.g. `Date`) as well as any attributes associated with that class (as written out by the `marshal_dump` method of the Ruby class). For example, here's the result of parsing the data marshalled by running `Marshal.dump(Date.today)` in Ruby:

  ```elixir
  iex(1)> value = <<4, 8, 85, 58, 9, 68, 97, 116, 101, 91, 11, 105, 0, 105, 3, 72, 136, 37, 105, 0, 105, 0, 105, 0, 102, 12, 50, 50, 57, 57, 49, 54, 49>>
  <<4, 8, 85, 58, 9, 68, 97, 116, 101, 91, 11, 105, 0, 105, 3, 72, 136, 37, 105,
  0, 105, 0, 105, 0, 102, 12, 50, 50, 57, 57, 49, 54, 49>>
  iex(2)> ExMarshal.decode(value)
  {:Date, [0, 2459720, 0, 0, 0, 2299161.0]}
  ```

2. `ExMarshal.decode` (and `ExMarshal.Decoder.decode`) now support taking options. The only supported option is called `user_object_parsers` which is expected to take a map associating Ruby class names (i.e. Elixir atoms) with unary functions processing the attributes written by Ruby. This is useful to customise the handling of user objects such that instead of getting a 2-tuple as shown above, custom Ruby types like `Date` get automatically converted to appropriate Elixir types. Here's an example showing how it can be used to convert Ruby dates to Elixir dates:

  ```elixir
  value = ...
  iex(3)> ExMarshal.decode(value, user_object_parsers: %{Date: fn [_, julian_day, _, _, _, _] -> Date.from_gregorian_days(julian_day - 1721425) end})
  ~D[2021-05-20]
  ```

Two plausible follow-up improvements come to mind:

* I'm not a `ExMemcached` user myself, but I suppose it would be plausible to also permit specifying custom parsers via configuration files such that the transcoder of Memcached would transparently map types using user object parsers.
* A new module `ExMarshal.CustomParsers` or such could be devised which implements custom parser functions for common Ruby types such as `Date`.