### PR TITLE
Fixes incompatible types warning

### DIFF
--- a/lib/ex_marshal/errors/decode_error.ex
+++ b/lib/ex_marshal/errors/decode_error.ex
@@ -2,7 +2,7 @@ defmodule ExMarshal.Errors.DecodeError do
   defexception [:reason]
 
   def message(%__MODULE__{} = exception) do
-    case exception.reason() do
+    case exception.reason do
       {:ivar_string_only, term} ->
         "only string ivars are supported: #{inspect(term)}"
       {:invalid_encoding, term} ->

--- a/lib/ex_marshal/errors/encode_error.ex
+++ b/lib/ex_marshal/errors/encode_error.ex
@@ -2,7 +2,7 @@ defmodule ExMarshal.Errors.EncodeError do
   defexception [:reason]
 
   def message(%__MODULE__{} = exception) do
-    case exception.reason() do
+    case exception.reason do
       {:not_supported, term} ->
         "the following type is not supported: #{inspect(term)}"
     end


### PR DESCRIPTION
A quick fix to clear up the following warnings:
```
warning: incompatible types:

    %ExMarshal.Errors.EncodeError{} !~ atom()

in expression:

    # lib/ex_marshal/errors/encode_error.ex:5
    exception.reason()

where "exception" was given the type %ExMarshal.Errors.EncodeError{} in:

    # lib/ex_marshal/errors/encode_error.ex:4
    %ExMarshal.Errors.EncodeError{} = exception

where "exception" was given the type atom() (due to calling var.fun()) in:

    # lib/ex_marshal/errors/encode_error.ex:5
    exception.reason()

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  lib/ex_marshal/errors/encode_error.ex:5: ExMarshal.Errors.EncodeError.message/1

warning: incompatible types:

    %ExMarshal.Errors.DecodeError{} !~ atom()

in expression:

    # lib/ex_marshal/errors/decode_error.ex:5
    exception.reason()

where "exception" was given the type %ExMarshal.Errors.DecodeError{} in:

    # lib/ex_marshal/errors/decode_error.ex:4
    %ExMarshal.Errors.DecodeError{} = exception

where "exception" was given the type atom() (due to calling var.fun()) in:

    # lib/ex_marshal/errors/decode_error.ex:5
    exception.reason()

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  lib/ex_marshal/errors/decode_error.ex:5: ExMarshal.Errors.DecodeError.message/1
```
